### PR TITLE
修复潜在的世界加载问题

### DIFF
--- a/PayWorld/src/main/resources/plugin.yml
+++ b/PayWorld/src/main/resources/plugin.yml
@@ -1,6 +1,9 @@
 name: PayWorld
 version: ${project.version}
 main: xyz.lvsheng.payworld.PayWorld
+softdepend: 
+  - Multiverse-Core
+  - MultiWorld
 commands:
   payworld:
     aliases:


### PR DESCRIPTION
我看了你的MCBBS帖子说明，有一条“**本插件载入时世界必须全部生成完毕,否则插件无法正常运行**”，所以把两个主流的多世界插件加到```softdepend```项里。

这样可以确保这个插件在这两个主流插件加载之后加载，就不会出现无法正常运行的问题。

---

既然仓库名称就是插件名称，为啥不把项目文件放到仓库根目录，还要再开一个新文件夹。而且你的分支名居然是你的插件名 :/
~~反正我是麻了~~